### PR TITLE
Name tools/clean name

### DIFF
--- a/JarvisEngine/core/name.py
+++ b/JarvisEngine/core/name.py
@@ -1,1 +1,16 @@
 SEP = "."
+
+def clean(name:str) -> str:
+    """clean name."""
+    if name[0] == SEP:
+        start = 1
+    else:
+        start = 0
+    
+    if name[-1] == SEP:
+        end = -1
+    else:
+        end = len(name)
+
+    return name[start:end]
+    

--- a/tests/core/test_name.py
+++ b/tests/core/test_name.py
@@ -2,3 +2,9 @@ from JarvisEngine.core import name
 
 def test_SEP():
     assert name.SEP == "."
+
+def test_clean():
+    assert name.clean("a.b.c") == "a.b.c"
+    assert name.clean("d.e.") == "d.e"
+    assert name.clean(".f.") == "f"
+    assert name.clean(".g.h") == "g.h"


### PR DESCRIPTION
From #50
This method does the following behavior.
```py
> clean(".a.b.c.")
--> "a.b.c" # remove extra `.`
```