### PR TITLE
Name tools/join

### DIFF
--- a/JarvisEngine/core/name.py
+++ b/JarvisEngine/core/name.py
@@ -14,3 +14,12 @@ def clean(name:str) -> str:
 
     return name[start:end]
     
+def join(name:str, *others:str) -> str:
+    """join names
+    Ex: join("a.b.","c.d") -> "a.b.c.d"
+    """
+    name = clean(name)
+    for n in others:
+        n = clean(n)
+        name = f"{name}{SEP}{n}"
+    return name

--- a/tests/core/test_name.py
+++ b/tests/core/test_name.py
@@ -8,3 +8,10 @@ def test_clean():
     assert name.clean("d.e.") == "d.e"
     assert name.clean(".f.") == "f"
     assert name.clean(".g.h") == "g.h"
+
+def test_join():
+    assert name.join("a","b") == "a.b"
+    assert name.join("a.b.c") == "a.b.c"
+    assert name.join(".a.b.","c.",".d") == "a.b.c.d"
+    assert name.join("a","b","c","d") == "a.b.c.d"
+    assert name.join(".a.b.c.d") == "a.b.c.d"


### PR DESCRIPTION
From #50 
This method works as follows.
```py
> join("a"," b","c.d")
--> "a.b.c.d"
```