### PR TITLE
Logging tool/get logger

### DIFF
--- a/JarvisEngine/core/logging_tool.py
+++ b/JarvisEngine/core/logging_tool.py
@@ -14,3 +14,10 @@ from logging_server import LoggingServer, SocketLogger as Logger
 import logging
 
 MAIN_LOGGER_NAME = "MAIN"
+
+def getLogger(name:str = None) -> logging.Logger:
+    """Return `logging.Logger`.
+    This interface will be used for 
+    adding default logger components.
+    """
+    return logging.getLogger(name)

--- a/tests/core/test_logging_tool.py
+++ b/tests/core/test_logging_tool.py
@@ -3,3 +3,7 @@ from JarvisEngine.core import logging_tool
 def test_MAIN_LOGGER_NAME():
     assert logging_tool.MAIN_LOGGER_NAME == "MAIN"
     
+def test_getLogger():
+    import logging
+    assert isinstance(logging_tool.getLogger(), logging.Logger)
+    


### PR DESCRIPTION
#6 
`getLogger`関数をlogging_tool.pyに追加しました。
この関数はJarvisEngineに必要なロガーコンポーネントを追加した上で返します。
現在はそのまま`logging.getLogger`の戻り値を返します。