### PR TITLE
Base app/properties

### DIFF
--- a/JarvisEngine/apps/base_app.py
+++ b/JarvisEngine/apps/base_app.py
@@ -1,4 +1,65 @@
-from ..core import Logger
 from attr_dict import AttrDict
 from folder_dict import FolderDict
 from typing import *
+
+class BaseApp(object):
+    """
+    The base class of all applications in JarvisEngine.
+    """
+
+
+    def __init__(
+        self, name:str, config:AttrDict, engine_config:AttrDict, 
+        project_config:AttrDict, app_dir:str = None
+    ) -> None:
+        """Initialization of BaseApp
+        Args:
+        - name
+            The name of this application, is given by 
+            its parent application.
+
+        - config
+            The config of the application.
+            This have the following attributes.
+            - path:str
+                The import name of its app.
+            - thread:bool
+                Whether its App is thread or process.
+            - apps (optional)
+                Children app configs of the application.
+
+        - engine_config
+            The launching configuration of JarvisEngine.
+            Please see `JarvisEngine/default_engine_config.toml`
+
+        - project_config
+            The whole configuration of applications.
+
+        - app_dir (optional)
+            The absolute path to the application folder.
+        """
+        self.__name = name
+        self.__config  = config
+        self.__engine_config = engine_config
+        self.__project_config = project_config
+        self.__app_dir = app_dir
+
+    @property
+    def name(self) -> str:
+        return self.__name
+
+    @property
+    def config(self) -> AttrDict:
+        return self.__config
+
+    @property
+    def engine_config(self) -> AttrDict:
+        return self.__engine_config
+    
+    @property
+    def project_config(self) -> AttrDict:
+        return self.__project_config
+
+    @property
+    def app_dir(self) -> str or None:
+        return self.__app_dir

--- a/TestEngineProject/config.json5
+++ b/TestEngineProject/config.json5
@@ -1,0 +1,21 @@
+{
+    App0: {
+        path: "App0.app.App0",
+        thread: true,
+    },
+    App1: {
+        path: "App1.app.App1",
+        thread: false,
+        apps: {
+            App1_1: {
+                path: "App1.App1_1.app.App1_1",
+                thread: true,
+                apps: {}
+            },
+            App1_2: {
+                path: "App1.App1_2.app.App1_2",
+                thread: true,
+            }
+        }
+    }
+}

--- a/tests/apps/test_base_app.py
+++ b/tests/apps/test_base_app.py
@@ -1,0 +1,36 @@
+from JarvisEngine.apps import base_app
+
+# prepare 
+from JarvisEngine.core.config_tools import read_json, read_toml, dict2attr
+from JarvisEngine.constants import DEFAULT_ENGINE_CONFIG_FILE
+TEST_CONFIG_FILE_PATH = "TestEngineProject/config.json5"
+
+project_config = dict2attr(read_json(TEST_CONFIG_FILE_PATH))
+
+engine_config = read_toml(DEFAULT_ENGINE_CONFIG_FILE)
+engine_config["logging"]["log_level"] = "DEBUG"
+engine_config = dict2attr(engine_config)
+
+def _check_property_override(app, attr:str):
+    try:
+        setattr(app, attr, None)
+        raise AssertionError(f"The property `{attr}` of {app} is overrided!")
+    except AttributeError: pass
+
+def test_properties():
+    name = "MAIN.App1.App1_1"
+    config = project_config.App1
+    app_dir = "TestEngineProject/App1/App1_1"
+    app = base_app.BaseApp(name, config, engine_config, project_config, app_dir)
+
+    assert app.name == name
+    assert app.config == config
+    assert app.engine_config == engine_config
+    assert app.project_config == project_config
+    assert app.app_dir == app_dir
+
+    _check_property_override(app, "name")
+    _check_property_override(app, "config")
+    _check_property_override(app, "engine_config")
+    _check_property_override(app, "project_config")
+    _check_property_override(app, "app_dir")


### PR DESCRIPTION
#16 #27 
Added args of `BaseApp.__init__` and set them as property.
 - name
    The name of this application, is given by 
    its parent application.

- config
    The config of the application.
    This have the following attributes.
    - path:str
        The import name of its app.
    - thread:bool
        Whether its App is thread or process.
    - apps (optional)
        Children app configs of the application.

 - engine_config
    The launching configuration of JarvisEngine.
    Please see `JarvisEngine/default_engine_config.toml`

- project_config
    The whole configuration of applications.

- app_dir (optional)
    The absolute path to the application folder.