### PR TITLE
Name tools/clean all sep

### DIFF
--- a/JarvisEngine/core/name.py
+++ b/JarvisEngine/core/name.py
@@ -1,14 +1,19 @@
 SEP = "."
 
 def clean(name:str) -> str:
-    """clean name."""
+    """clean name.
+    Erase all SEP's at the head and tail of name.
+    Ex:
+        "..a.b.c.." -> "a.b.c"
+        ".d.e" -> "d.e"
+    """
     if name[0] == SEP:
-        start = 1
+        start = count_head_sep(name)
     else:
         start = 0
     
     if name[-1] == SEP:
-        end = -1
+        end = -count_head_sep(name[::-1])
     else:
         end = len(name)
 

--- a/tests/core/test_name.py
+++ b/tests/core/test_name.py
@@ -8,6 +8,10 @@ def test_clean():
     assert name.clean("d.e.") == "d.e"
     assert name.clean(".f.") == "f"
     assert name.clean(".g.h") == "g.h"
+    
+    assert name.clean("..a.b.c..") == "a.b.c"
+    assert name.clean("..d.e") == "d.e"
+    assert name.clean("f....") == "f"
 
 def test_join():
     assert name.join("a","b") == "a.b"


### PR DESCRIPTION
From #50 #78
Updated #54 
    Erase all SEP's at the head and tail of name.
    Ex:
        "..a.b.c.." -> "a.b.c"
        ".d.e" -> "d.e"