### PR TITLE
Name tools/join relatively

### DIFF
--- a/JarvisEngine/core/name.py
+++ b/JarvisEngine/core/name.py
@@ -33,6 +33,23 @@ def count_head_sep(name:str) -> int:
             num += 1
     return num
 
+def join_relatively(name:str, another:str) -> str:
+    """Join another to name.
+    Ex:
+        join_relatively("a.b.c","..d.e") -> "a.b.d.e"
+        join_relatively("a.", "...d.e.f") -> "d.e.f"
+    """
+    name = clean(name)
+    n_sep = count_head_sep(another) - 1
+    if n_sep > 0:
+        splited = name.split(SEP)[:-n_sep]
+        name = SEP.join(splited)
+    another = clean(another)
+    if name == "":
+        return another
+    else:
+        return f"{name}{SEP}{another}"
+
 def join(name:str, *others:str) -> str:
     """join names
     Ex: join("a.b.","c.d") -> "a.b.c.d"

--- a/tests/core/test_name.py
+++ b/tests/core/test_name.py
@@ -26,4 +26,10 @@ def test_count_head_sep():
     assert name.count_head_sep(".....") == 5
     assert name.count_head_sep("asf....") == 0
     assert name.count_head_sep("..v..s..a.sd") == 2
-    
+
+
+def test_join_relatively():
+    assert name.join_relatively("a.b.c","..d.e") == "a.b.d.e"
+    assert name.join_relatively("a.", "...d.e.f") == "d.e.f"
+    assert name.join_relatively("a.b.c",".d.e") == "a.b.c.d.e"
+    assert name.join_relatively("a","b") == "a.b"


### PR DESCRIPTION
From #50 #78 
Join another to name.
    Ex:
        join_relatively("a.b.c","..d.e") -> "a.b.d.e"
        join_relatively("a.", "...d.e.f") -> "d.e.f"