### PR TITLE
Name tools/join

### DIFF
--- a/JarvisEngine/core/name.py
+++ b/JarvisEngine/core/name.py
@@ -51,11 +51,12 @@ def join_relatively(name:str, another:str) -> str:
         return f"{name}{SEP}{another}"
 
 def join(name:str, *others:str) -> str:
-    """join names
-    Ex: join("a.b.","c.d") -> "a.b.c.d"
+    """join names. Supported relative join.
+    Ex: 
+        join("a.b.","c.d") -> "a.b.c.d"
+        join("a.b.c","..d.e","...e.c") -> "a.b.e.c"
     """
     name = clean(name)
     for n in others:
-        n = clean(n)
-        name = f"{name}{SEP}{n}"
+        name = join_relatively(name, n)
     return name

--- a/tests/core/test_name.py
+++ b/tests/core/test_name.py
@@ -19,6 +19,7 @@ def test_join():
     assert name.join(".a.b.","c.",".d") == "a.b.c.d"
     assert name.join("a","b","c","d") == "a.b.c.d"
     assert name.join(".a.b.c.d") == "a.b.c.d"
+    assert name.join("a.b.c","..d.e","...e.c") == "a.b.e.c"
 
 def test_count_head_sep():
     assert name.count_head_sep("..a.b.") == 2


### PR DESCRIPTION
From #50 #78 
updated #55
join names. Supported relative join.
    Ex: 
        join("a.b.","c.d") -> "a.b.c.d"
        join("a.b.c","..d.e","...e.c") -> "a.b.e.c"