### PR TITLE
Base app/construct child apps

### DIFF
--- a/JarvisEngine/apps/base_app.py
+++ b/JarvisEngine/apps/base_app.py
@@ -10,6 +10,10 @@ from collections import OrderedDict
 class BaseApp(object):
     """
     The base class of all applications in JarvisEngine.
+    Attrs:
+    - child_apps  
+        The ordered dictionary that contains constructed child apps.
+        self.child_apps["child_name"] -> child app
     """
 
 

--- a/JarvisEngine/apps/base_app.py
+++ b/JarvisEngine/apps/base_app.py
@@ -1,7 +1,11 @@
+from __future__ import annotations
 from attr_dict import AttrDict
 from folder_dict import FolderDict
 from typing import *
-from ..core import logging_tool
+from ..core import logging_tool, name as name_tools
+import importlib
+import os
+from collections import OrderedDict
 
 class BaseApp(object):
     """
@@ -48,6 +52,7 @@ class BaseApp(object):
         
         self.set_config_attrs()
 
+        self.construct_child_apps()
 
     @property
     def name(self) -> str:
@@ -89,4 +94,25 @@ class BaseApp(object):
             self.child_app_configs = self.config.apps
         else:
             self.child_app_configs = AttrDict()    
+
+    def construct_child_apps(self):
+        """Construct child applications of this.
+        you can see constructed child apps 
+        by `self.child_apps` attribute.
+        """
+        self.child_apps = OrderedDict()
+        for child_name, child_conf in self.child_app_configs.items():
+            ch_path:str = child_conf.path 
+            
+            full_child_name = name_tools.join(self.name, child_name)
+            mod_name, cls_name = ch_path.rsplit(".",1)
+            mod = importlib.import_module(mod_name)
+            app_cls:BaseApp = getattr(mod,cls_name)
+            app_dir = os.path.dirname(mod.__file__)
+
+            child_app = app_cls(
+                full_child_name, child_conf,self.engine_config,
+                self.project_config, app_dir
+            )
+            self.child_apps[child_name] = child_app
         


### PR DESCRIPTION
#27 #16 
From https://github.com/Geson-anko/JarvisEngine/issues/27#issuecomment-1120566127

ADD `construct_child_apps` method and its test.

**WARNING**
Changing the current working directory with `os.chdir` does not add the destination directory to `sys.path`.
So, we must execute `sys.path.insert(0, os.getcwd())` after `os.chdir`.