### PR TITLE
Launcher/to project config

### DIFF
--- a/JarvisEngine/apps/launcher.py
+++ b/JarvisEngine/apps/launcher.py
@@ -1,10 +1,35 @@
 from .base_app import BaseApp, AttrDict
 from typing import *
 import os
+from ..core import logging_tool
+
+def to_project_config(config:AttrDict) -> AttrDict:
+    """convert `config` to `project_config`
+    `project_config` has the following structure.
+    ```
+    {
+        MAIN: {
+            path: "JarvisEngine.apps.Launcher",
+            thread: true,
+            apps: config
+        }
+
+    }
+    ```
+    """
+    pconf_dict = {
+        logging_tool.MAIN_LOGGER_NAME:{
+            "path": "JarvisEngine.apps.Launcher",
+            "thread": True,
+            "apps": config
+        }
+    }
+    project_config = AttrDict(pconf_dict)
+    return project_config
 
 class Launcher(BaseApp):
     """The origin of appcation processes.
-    
+
     """
 
     def __init__(
@@ -12,4 +37,3 @@ class Launcher(BaseApp):
         engine_config: AttrDict, project_config:AttrDict
     ) -> None:
         super().__init__(name, config, engine_config, project_config, os.path.dirname(__file__))
-

--- a/tests/apps/test_launcher.py
+++ b/tests/apps/test_launcher.py
@@ -1,1 +1,15 @@
 from JarvisEngine.apps import launcher
+from attr_dict import AttrDict
+import importlib
+
+def test_to_project_config():
+    config = AttrDict()
+    proj_conf = launcher.to_project_config(config)
+    assert "MAIN" in proj_conf
+    launcher_conf = proj_conf.MAIN
+    assert launcher_conf.path == "JarvisEngine.apps.Launcher"
+    mod, app = launcher_conf.path.rsplit(".",1)
+    assert getattr(importlib.import_module(mod), app) == launcher.Launcher
+    assert launcher_conf.thread == True
+    assert isinstance(launcher_conf.apps, AttrDict)
+    assert launcher_conf.apps == config


### PR DESCRIPTION
#99
This method converts `config` to `project_config` that stores the whole application structure of the project.
```
    {
        MAIN: {
            path: "JarvisEngine.apps.Launcher",
            thread: true,
            apps: config // <---- config.json5
        }

    }
```