### PR TITLE
Value sharing/read only classes

### DIFF
--- a/JarvisEngine/core/value_sharing.py
+++ b/JarvisEngine/core/value_sharing.py
@@ -1,0 +1,99 @@
+import multiprocessing as mp
+from multiprocessing.sharedctypes import Synchronized, SynchronizedArray,SynchronizedString
+from typing import *
+
+class ReadOnlyError(Exception): pass 
+
+class ReadOnly(object):
+    """Read Only Synchronized object.
+    Wrapps `multiprocessing.sharedctypes.SynchronizedBase`.
+    """
+    def __init__(self, value:Union[Synchronized, SynchronizedString, SynchronizedArray]) -> None:
+        self._obj = value
+        self._lock = value.get_lock()
+        self.acquire = self._lock.acquire
+        self.release = self._lock.release
+
+    def __enter__(self):
+        return self._lock.__enter__()
+
+    def __exit__(self, *args):
+        return self._lock.__exit__(*args)
+    
+    def __reduce__(self):
+        return self._obj.__reduce__()
+
+    def get_obj(self):
+        return self._obj.get_obj()
+    
+    def get_lock(self):
+        return self._obj.get_lock()
+
+    def __repr__(self) -> str:
+        return f"ReadOnly{repr(self._obj)}"
+
+    def get_type(self):
+        return type(self._obj)
+
+class ReadOnlyValue(ReadOnly):
+    """Wrapps `multiprocessing.sharedctypes.Synchronized`"""
+
+    @property
+    def value(self):
+        return self._obj.value
+
+    @value.setter
+    def value(*args):
+        raise ReadOnlyError
+
+class ReadOnlyArray(ReadOnly):
+    """Wrapps `multiprocessing.sharedctypes.SynchronizedArray`"""
+
+    def __len__(self):
+        return len(self._obj)
+
+    def __getitem__(self, i):
+        return self._obj[i]
+
+    def __getslice__(self, start, stop):
+        return self._obj[start, stop]
+    
+    def __setitem__(*args):
+        raise ReadOnlyError
+
+    def __setslice__(*args):
+        raise ReadOnlyError
+
+class ReadOnlyString(ReadOnlyArray):
+    """Wrapps `multiprocessing.sharedctypes.SynchronizedString`"""
+
+    @property
+    def value(self):
+        return self._obj.value
+
+    @property
+    def raw(self):
+        return self.raw
+    
+    @value.setter
+    def value(*args):
+        raise ReadOnlyError
+
+    @raw.setter
+    def raw(*args):
+        raise ReadOnlyError
+
+def make_readonly(
+    value: Union[Synchronized, SynchronizedArray, SynchronizedString]
+    ) -> Union[ReadOnlyValue,ReadOnlyArray,ReadOnlyString]:
+    """Make synchronized objects readonly."""
+
+    if isinstance(value, Synchronized):
+        return ReadOnlyValue(value)
+    elif isinstance(value, SynchronizedString): # check before array.
+        return ReadOnlyString(value)
+    elif isinstance(value, SynchronizedArray):
+        return ReadOnlyArray(value)
+    else:
+        raise ValueError(f"Unknown type {type(value)}. "
+        "Please Synchronized, SynchronizedArray or SynchronizedString.")

--- a/tests/core/test_value_sharing.py
+++ b/tests/core/test_value_sharing.py
@@ -1,0 +1,104 @@
+from JarvisEngine.core import value_sharing
+from JarvisEngine.core.value_sharing import (
+    ReadOnly, ReadOnlyError, ReadOnlyValue, ReadOnlyArray, ReadOnlyString
+)
+import multiprocessing as mp
+import ctypes
+
+def assert_modify_value(obj: ReadOnlyValue):
+    try:
+        obj.value = None
+        raise AssertionError
+    except ReadOnlyError: pass
+
+def assert_modify_array(obj: ReadOnlyArray):
+    try:
+        obj[0] = None
+        raise AssertionError
+    except ReadOnlyError:
+        try:
+            obj[:] = None
+        except ReadOnlyError: pass
+
+def assert_modify_string(obj: ReadOnlyString):
+    try:
+        obj.raw = None
+        raise AssertionError
+    except ReadOnlyError:
+        assert_modify_value(obj)
+        assert_modify_array(obj)
+
+def test_ReadOnly():
+    value = mp.Value(ctypes.c_int,0)
+    ro = ReadOnly(value)
+
+    assert ro._obj == value
+    assert ro._lock == value._lock
+    assert ro.get_lock() == value.get_lock()
+    assert ro.get_obj() == value.get_obj()
+    assert ro.acquire == value.acquire
+    assert ro.release == value.release
+    assert repr(ro) == f"ReadOnly{repr(value)}"
+    assert ro.get_type() == type(value)
+    
+def test_ReadOnlyValue():
+    v0 = mp.Value(ctypes.c_bool)
+    v1 = mp.Value(ctypes.c_float)
+    ro0 = ReadOnlyValue(v0)
+    ro1 = ReadOnlyValue(v1)
+    assert issubclass(ReadOnlyValue, ReadOnly)
+    assert ro0.value == v0.value
+    assert ro1.value == v1.value
+    assert_modify_value(ro0)
+    assert_modify_value(ro1)
+
+def test_ReadOnlyArray():
+    a0 = mp.Array(ctypes.c_longdouble,10)
+    a1 = mp.Array(ctypes.c_bool, 3)
+    roa0 = ReadOnlyArray(a0)
+    roa1 = ReadOnlyArray(a1)
+
+    assert len(roa0) == 10
+    assert len(roa1) == 3
+    assert roa0[0] == a0[0]
+    assert roa1[2] == a1[2]
+    assert roa0[:4] == a0[:4]
+    assert roa1[0:10] == a1[0:10]
+
+    assert_modify_array(roa0)
+    assert_modify_array(roa1)
+
+def test_ReadOnlyString():
+    s0 = mp.Array(ctypes.c_char, 10)
+    ros0 = ReadOnlyString(s0)
+    
+    assert len(ros0) == 10
+    assert ros0[1] == s0[1]
+    assert ros0[3:10] == s0[3:10]
+    
+    assert_modify_string(ros0)
+
+def test_make_readonly():
+    
+    v = mp.Value("i")
+    a = mp.Array(ctypes.c_uint8,3)
+    s = mp.Array(ctypes.c_char, 10)
+
+    rov = value_sharing.make_readonly(v)
+    roa = value_sharing.make_readonly(a)
+    ros = value_sharing.make_readonly(s)
+
+    assert isinstance(rov, ReadOnlyValue)
+    assert isinstance(roa, ReadOnlyArray)
+    assert isinstance(ros, ReadOnlyString)
+
+    try:
+        value_sharing.make_readonly(None)
+        raise AssertionError
+    except ValueError: pass
+
+
+
+
+
+


### PR DESCRIPTION
From #106 https://github.com/Geson-anko/JarvisEngine/issues/106#issuecomment-1127550235
Implemented `ReadOnly` classes that wraps `Synchronized` objects and a function makes it readonly class.
- ReadOnly: wrapper for `SynchronizedBase`.
- ReadOnlyValue: wrapper for `Synchronized`
- ReadOnlyArray: wrapper for `SynchronizedArray`
- ReadOnlyString: wrapper for `SynchronizedString`
- make_readonly: make `Synchronized` objects `ReadOnly`.