### PR TITLE
Base app/child thread apps

### DIFF
--- a/JarvisEngine/apps/base_app.py
+++ b/JarvisEngine/apps/base_app.py
@@ -20,6 +20,10 @@ class BaseApp(object):
         The ordered dictionary that contains constructed child apps.
         self.child_apps["child_name"] -> child app
 
+    - child_thread_apps: OrderedDict
+        Contains child apps that are launched as a thread.
+        They are `is_thread=True`.
+
     - logger: Logger
         The logger for multiprocessing logging.
 
@@ -142,6 +146,8 @@ class BaseApp(object):
         by `self.child_apps` attribute.
         """
         self.child_apps = OrderedDict()
+        self.child_thread_apps = OrderedDict()
+
         for child_name, child_conf in self.child_app_configs.items():
             ch_path:str = child_conf.path 
             
@@ -154,6 +160,8 @@ class BaseApp(object):
                 self.project_config, app_dir
             )
             self.child_apps[child_name] = child_app
+            if child_app.is_thread:
+                self.child_thread_apps[child_name] = child_app
 
     @staticmethod
     def import_app(path:str) -> Tuple[BaseApp, ModuleType]:

--- a/tests/apps/test_base_app.py
+++ b/tests/apps/test_base_app.py
@@ -99,8 +99,15 @@ def test__init__():
     assert App1_2.module_name == "App1.App1_2.app.App1_2"
     assert App1_1.is_thread == True
     assert App1_2.is_thread == False
+    ### child_thread_apps
+    assert "App1_1" in app.child_thread_apps
+    assert "App1_2" not in app.child_thread_apps
+    App1_1 = app.child_thread_apps["App1_1"]
+    assert App1_1.is_thread == True
+
     apps = config.apps
     assert App1_1.config == apps.App1_1
     assert App1_2.config == apps.App1_2
     assert App1_1.app_dir == os.path.join(app_dir, "App1_1")
     assert App1_2.app_dir == os.path.join(app_dir, "App1_2")
+


### PR DESCRIPTION
#16 
ADD attribute `BaseApp.child_thread_apps`, that contains child applications launching as a thread.
It is OrderedDict