### PR TITLE
Base app/register process shared values#126

### DIFF
--- a/JarvisEngine/apps/base_app.py
+++ b/JarvisEngine/apps/base_app.py
@@ -7,7 +7,7 @@ from ..core.value_sharing import FolderDict_withLock
 import importlib
 import os
 from collections import OrderedDict
-
+from multiprocessing.managers import SyncManager
 class BaseApp(object):
     """
     The base class of all applications in JarvisEngine.
@@ -252,3 +252,20 @@ class BaseApp(object):
         """Interface of `_add_shared_value`"""
         return self._add_shared_value(obj_name, obj,True)
 
+    def RegisterProcessSharedValues(self, sync_manager: SyncManager) -> None:
+        """Override function.
+        Register value for sharing inter `multiprocessing`.
+        You must call `super().RegisterProcessSharedValues` in your override
+        because it registers default values that all applications must share.
+        
+        Usage:
+            Please use `addProcessSharedValue` method to register a shared object.
+            The object will be stored into `self.process_shared_values`.
+            You can see other shared objects after process launched.
+            
+
+        Args:
+            - sync_manager
+                return value of `multiprocessing.Manager`.
+                Please use it for sharing values.
+        """

--- a/JarvisEngine/apps/base_app.py
+++ b/JarvisEngine/apps/base_app.py
@@ -256,16 +256,19 @@ class BaseApp(object):
         """Override function.
         Register value for sharing inter `multiprocessing`.
         You must call `super().RegisterProcessSharedValues` in your override
-        because it registers default values that all applications must share.
+        because it calls `<child_app>.RegisterProcessSharedValues`.
         
         Usage:
             Please use `addProcessSharedValue` method to register a shared object.
             The object will be stored into `self.process_shared_values`.
             You can see other shared objects after process launched.
-            
+
 
         Args:
             - sync_manager
                 return value of `multiprocessing.Manager`.
                 Please use it for sharing values.
         """
+        for app in self.child_apps.values():
+            app.RegisterProcessSharedValues(sync_manager)
+

--- a/tests/apps/test_base_app.py
+++ b/tests/apps/test_base_app.py
@@ -8,6 +8,7 @@ from JarvisEngine.apps.launcher import to_project_config
 import os
 import sys
 from JarvisEngine.core.value_sharing import FolderDict_withLock
+import multiprocessing as mp
 
 PROJECT_DIR = "TestEngineProject"
 sys.path.insert(0,os.path.join(os.getcwd(),PROJECT_DIR))
@@ -259,3 +260,14 @@ def test_addThreadSharedValue():
     assert MainApp.thread_shared_values["MAIN.fff"] == 60
     assert MainApp.thread_shared_values["MAIN.ggg"] == 70
     assert MainApp.thread_shared_values["MAIN.hhh"] == 80
+
+@_cd_project_dir
+def test_RegisterProcessSharedValues():
+    name = "MAIN"
+    config = project_config.MAIN
+    app_dir = PROJECT_DIR
+    MainApp = base_app.BaseApp(name, config, engine_config,project_config,app_dir)
+    fdwl= FolderDict_withLock(sep=".")
+    MainApp.set_process_shared_values_to_all_apps(fdwl)
+    with mp.Manager() as shmm:
+        MainApp.RegisterProcessSharedValues(shmm)


### PR DESCRIPTION
#126 #16 #109
regarding #124 
Override function.
        Register value for sharing inter `multiprocessing`.
        You must call `super().RegisterProcessSharedValues` in your override
        because it calls `<child_app>.RegisterProcessSharedValues`.
        
        Usage:
            Please use `addProcessSharedValue` method to register a shared object.
            The object will be stored into `self.process_shared_values`.
            You can see other shared objects after process launched.


        Args:
            - sync_manager
                return value of `multiprocessing.Manager`.
                Please use it for sharing values.