### PR TITLE
Launcher/is_thread=False

### DIFF
--- a/JarvisEngine/apps/launcher.py
+++ b/JarvisEngine/apps/launcher.py
@@ -24,7 +24,7 @@ def to_project_config(config:AttrDict) -> AttrDict:
     pconf_dict = {
         logging_tool.MAIN_LOGGER_NAME:{
             "path": "JarvisEngine.apps.Launcher",
-            "thread": True,
+            "thread": False,
             "apps": config
         }
     }

--- a/tests/apps/test_launcher.py
+++ b/tests/apps/test_launcher.py
@@ -20,7 +20,7 @@ def test_to_project_config():
     assert launcher_conf.path == "JarvisEngine.apps.Launcher"
     mod, app = launcher_conf.path.rsplit(".",1)
     assert getattr(importlib.import_module(mod), app) == launcher.Launcher
-    assert launcher_conf.thread == True
+    assert launcher_conf.thread == False
     assert isinstance(launcher_conf.apps, AttrDict)
     assert launcher_conf.apps == config
 


### PR DESCRIPTION
#99 
Because `Launcher` app is the origin of Python Process.
