### PR TITLE
Base app/launch

### DIFF
--- a/tests/apps/test_base_app_launch.py
+++ b/tests/apps/test_base_app_launch.py
@@ -1,0 +1,45 @@
+from JarvisEngine.apps.base_app import BaseApp
+
+# prepare 
+import time
+from JarvisEngine.core.logging_tool import getLoggingServer
+from JarvisEngine.core.value_sharing import FolderDict_withLock
+from JarvisEngine.apps.launcher import Launcher
+from .test_base_app import (
+    project_config, engine_config,PROJECT_DIR
+)
+from logging import INFO, WARNING
+import os
+import copy
+import multiprocessing as mp
+
+engine_config = copy.deepcopy(engine_config)
+engine_config.logging.port = 20223
+ls = getLoggingServer(engine_config.logging)
+ls.start()
+
+class cd_project_dir:
+    def __enter__(self):
+        os.chdir(PROJECT_DIR)
+    def __exit__(self, *args):
+        os.chdir("..")
+
+def test_launch(caplog):
+    name = "MAIN"
+    config = project_config.MAIN
+    app_dir = PROJECT_DIR
+    with cd_project_dir(), mp.Manager() as sync_manager:
+        MainApp = BaseApp(name, config, engine_config, project_config,app_dir)
+        p_sv = Launcher.prepare_for_launching(MainApp, sync_manager)
+        MainApp.launch(p_sv)
+        time.sleep(0.1)
+        rec_tup = caplog.record_tuples
+
+        assert ("MAIN", INFO, "launch") in rec_tup
+        assert ("MAIN.App0", INFO, "launch") in rec_tup
+        assert ("MAIN.App1", INFO, "launch") in rec_tup
+        assert ("MAIN.App1.App1_1", INFO, "launch") in rec_tup
+        assert ("MAIN.App1.App1_2", INFO, "launch") in rec_tup
+        
+    for record in caplog.records:
+        assert record.levelno < WARNING, record.message


### PR DESCRIPTION
#16 #107 
現状、ただ起動するだけです。
ADD following methods.
- launch_child_apps
子アプリケーションを`self.process_shared_values`を引数に渡して起動します。
- join_child_apps
launch_child_appsで起動したアプリケーションthread/processをjoinします。
- _launch
メインの処理です。
- launch
try-exceptで`_launch`をラップしてエラーメッセージをロガーに渡します。