### PR TITLE
Base app/awake

### DIFF
--- a/JarvisEngine/apps/base_app.py
+++ b/JarvisEngine/apps/base_app.py
@@ -57,6 +57,8 @@ class BaseApp(object):
     Override methods
     - Init()  
         called at end of `__init__`
+    - Awake()
+        Called at the begin of process/thread.
     """
 
 
@@ -364,6 +366,8 @@ class BaseApp(object):
         Launch all applications as other threads or processes.
         """
         self.logger.info("launch")
+        self.Awake()
+
         self.process_shared_values = process_shared_values
         self.prepare_for_launching_thread_apps()
         self.launch_child_apps()
@@ -380,3 +384,5 @@ class BaseApp(object):
             self.logger.exception(e)
         
 
+    def Awake(self) -> None:
+        """Called at begin of process/thread."""

--- a/TestEngineProject/App0/app.py
+++ b/TestEngineProject/App0/app.py
@@ -12,3 +12,9 @@ class App0(BaseApp):
     def RegisterThreadSharedValues(self) -> None:
         super().RegisterThreadSharedValues()
         self.addThreadSharedValue("set_obj", {"number"})
+
+    def Awake(self) -> None:
+        self.logger.info("Awake")
+        assert self.process_shared_values == None
+
+    

--- a/TestEngineProject/App1/App1_1/app.py
+++ b/TestEngineProject/App1/App1_1/app.py
@@ -13,3 +13,7 @@ class App1_1(BaseApp):
     def RegisterThreadSharedValues(self) -> None:
         super().RegisterThreadSharedValues()
         self.addThreadSharedValue("tuple_obj",(True,False))
+
+    def Awake(self) -> None:
+        self.logger.info("Awake")
+        assert self.process_shared_values == None

--- a/TestEngineProject/App1/App1_2/app.py
+++ b/TestEngineProject/App1/App1_2/app.py
@@ -12,3 +12,7 @@ class App1_2(BaseApp):
     def RegisterThreadSharedValues(self) -> None:
         super().RegisterThreadSharedValues()
         self.addThreadSharedValue("list_obj", [1,2,3])
+
+    def Awake(self) -> None:
+        self.logger.info("Awake")
+        assert self.process_shared_values == None

--- a/TestEngineProject/App1/app.py
+++ b/TestEngineProject/App1/app.py
@@ -14,3 +14,7 @@ class App1(BaseApp):
     def RegisterThreadSharedValues(self) -> None:
         super().RegisterThreadSharedValues()
         self.addThreadSharedValue("range_obj",range(10))
+
+    def Awake(self) -> None:
+        self.logger.info("Awake")
+        assert self.process_shared_values == None

--- a/tests/apps/test_base_app_launch.py
+++ b/tests/apps/test_base_app_launch.py
@@ -35,11 +35,18 @@ def test_launch(caplog):
         time.sleep(0.1)
         rec_tup = caplog.record_tuples
 
+        # launch
         assert ("MAIN", INFO, "launch") in rec_tup
         assert ("MAIN.App0", INFO, "launch") in rec_tup
         assert ("MAIN.App1", INFO, "launch") in rec_tup
         assert ("MAIN.App1.App1_1", INFO, "launch") in rec_tup
         assert ("MAIN.App1.App1_2", INFO, "launch") in rec_tup
         
+        # Awake
+        assert ("MAIN.App0", INFO, "Awake") in rec_tup
+        assert ("MAIN.App1", INFO, "Awake") in rec_tup
+        assert ("MAIN.App1.App1_1", INFO, "Awake") in rec_tup
+        assert ("MAIN.App1.App1_2", INFO, "Awake") in rec_tup
+
     for record in caplog.records:
         assert record.levelno < WARNING, record.message


### PR DESCRIPTION
#16 #107 #89 
ADD Awake method. it is called at the begin of process/thread.
And at `Awake()` called,  `process_shared_values` must be `None`.