### PR TITLE
Update __main__.py

### DIFF
--- a/JarvisEngine/__main__.py
+++ b/JarvisEngine/__main__.py
@@ -1,9 +1,10 @@
 from . import run_project
 from . import create_project
 from .core import parsers
-
+import multiprocessing as mp
 
 if __name__ == "__main__":
+    mp.set_start_method('spawn')
     parser = parsers.at_launching()
     args,unknow = parser.parse_known_args()
     


### PR DESCRIPTION
mp.set_start_method('spawn')
JarvisEngineでは多重にスレッド、プロセスを起動するため`fork`を使用することができません。