### PR TITLE
Feature/#155multiprocessing spawn method

### DIFF
--- a/JarvisEngine/default_engine_config.toml
+++ b/JarvisEngine/default_engine_config.toml
@@ -3,3 +3,6 @@ host = "127.0.0.1"
 port = 8316
 message_format = "%(asctime)s.%(msecs)03d %(name)s [%(levelname)s]: %(message)s"
 date_format = "%Y/%m/%d %H:%M:%S"
+
+[multiprocessing]
+start_method = "spawn" # or "fork". If using "fork", you may face freeze problems caused by multi process threading. 

--- a/JarvisEngine/run_project.py
+++ b/JarvisEngine/run_project.py
@@ -41,6 +41,11 @@ def run():
     ### starting logging server
     logging_server = logging_tool.getLoggingServer(engine_config.logging)
     logging_server.start()
+
+    # set process spawn method
+    start_method = engine_config.multiprocessing.start_method
+    mp.set_start_method(start_method)
+
     try:
         logger.info("JarvisEngine launch.")
         main_process(config, engine_config, project_dir)

--- a/tests/test_default_files.py
+++ b/tests/test_default_files.py
@@ -9,3 +9,7 @@ def test_default_engine_config():
     assert log_conf["port"] == 8316
     assert log_conf["message_format"] == "%(asctime)s.%(msecs)03d %(name)s [%(levelname)s]: %(message)s"
     assert log_conf["date_format"] == "%Y/%m/%d %H:%M:%S"
+
+    assert "multiprocessing" in conf
+    mp_conf = conf["multiprocessing"]
+    assert mp_conf["start_method"] == "spawn"


### PR DESCRIPTION
#155 https://github.com/Geson-anko/JarvisEngine/issues/26#issuecomment-1134097839
JarvisEngineのデフォルトの`multiprocessing` start method を`spawn`にしました。
特定の場合においてのみ、`fork`を使用することができます。