### PR TITLE
Run project/create shutdown

### DIFF
--- a/JarvisEngine/run_project.py
+++ b/JarvisEngine/run_project.py
@@ -2,11 +2,14 @@ from .core import parsers, logging_tool
 from .core.config_tools import read_toml, read_json, dict2attr, deep_update
 import os
 from attr_dict import AttrDict
-from .constants import DEFAULT_ENGINE_CONFIG_FILE
+from .constants import DEFAULT_ENGINE_CONFIG_FILE, SHUTDOWN_NAME
 from typing import *
 import sys
 from .apps import Launcher
 import multiprocessing as mp
+from multiprocessing.sharedctypes import Synchronized
+from .core.value_sharing import make_readonly, FolderDict_withLock
+import ctypes
 
 logger = logging_tool.getLogger(logging_tool.MAIN_LOGGER_NAME)
 
@@ -64,3 +67,14 @@ def main_process(config: AttrDict, engine_config:AttrDict, project_dir:str) -> N
         launcher.launch(p_sv)
 
         launcher.join()
+
+def create_shutdown(process_shared_values:FolderDict_withLock) -> Synchronized:
+    """
+    Creates a shutdown value and share it inter all app processes.
+    The shared shutdown value is readonly.
+    Returns pure shutdown value (writable).
+    """
+    shutdown = mp.Value(ctypes.c_bool, False)
+    shutdown_read_only = make_readonly(shutdown)
+    process_shared_values[SHUTDOWN_NAME] = shutdown_read_only
+    return shutdown

--- a/tests/test_run_project.py
+++ b/tests/test_run_project.py
@@ -1,0 +1,18 @@
+from JarvisEngine.run_project import create_shutdown
+
+# prepare
+from JarvisEngine.constants import SHUTDOWN_NAME
+from JarvisEngine.core.value_sharing import (
+    ReadOnlyValue, FolderDict_withLock
+)
+from multiprocessing.sharedctypes import Synchronized
+
+def test_create_shutdown():
+    fdwl = FolderDict_withLock()
+    shutdown = create_shutdown(fdwl)
+    shutdown_readonly = fdwl[SHUTDOWN_NAME]
+    
+    assert isinstance(shutdown, Synchronized)
+    assert isinstance(shutdown_readonly, ReadOnlyValue)
+    assert shutdown.value == False
+    assert shutdown_readonly.value == False


### PR DESCRIPTION
#92 #160 
Creates a shutdown value and share it inter all app processes.
The shared shutdown value is readonly.
Returns pure shutdown value (writable).