### PR TITLE
Base app/terminate

### DIFF
--- a/JarvisEngine/apps/base_app.py
+++ b/JarvisEngine/apps/base_app.py
@@ -78,6 +78,10 @@ class BaseApp(object):
         Called at intervals determined by `frame_rate` attribute.
     - End()
         Called at the end of process/thread.
+    - Terminate()
+        Called before the app terminate.
+        If child applications could not be terminated,
+        this method is never called.
     """
 
 
@@ -399,6 +403,9 @@ class BaseApp(object):
 
         self.join_child_apps()
 
+        self.Terminate()
+        self.logger.debug("terminate")
+
     def launch(self, process_shared_values:FolderDict_withLock) -> None:
         """
         Wrapps `self._launch` by try-except error catching.
@@ -462,3 +469,10 @@ class BaseApp(object):
 
     def End(self) -> None:
         """Called at the end of process/thread."""
+
+    def Terminate(self) -> None:
+        """
+        Called before the app terminate.
+        If child applications could not be terminated,
+        this method is never called.
+        """

--- a/TestEngineProject/App0/app.py
+++ b/TestEngineProject/App0/app.py
@@ -41,3 +41,6 @@ class App0(BaseApp):
 
     def End(self) -> None:
         self.logger.info("End")
+
+    def Terminate(self) -> None:
+        self.logger.info("Terminate.")

--- a/TestEngineProject/App1/App1_1/app.py
+++ b/TestEngineProject/App1/App1_1/app.py
@@ -43,3 +43,6 @@ class App1_1(BaseApp):
 
     def End(self) -> None:
         self.logger.info("End")
+
+    def Terminate(self) -> None:
+        self.logger.info("Terminate.")

--- a/TestEngineProject/App1/App1_2/app.py
+++ b/TestEngineProject/App1/App1_2/app.py
@@ -43,3 +43,6 @@ class App1_2(BaseApp):
 
     def End(self) -> None:
         self.logger.info("End")
+
+    def Terminate(self) -> None:
+        self.logger.info("Terminate.")

--- a/TestEngineProject/App1/app.py
+++ b/TestEngineProject/App1/app.py
@@ -47,3 +47,6 @@ class App1(BaseApp):
 
     def End(self) -> None:
         self.logger.info("End")
+
+    def Terminate(self) -> None:
+        self.logger.info("Terminate.")

--- a/tests/apps/test_base_app_launch.py
+++ b/tests/apps/test_base_app_launch.py
@@ -92,5 +92,18 @@ def test_launch(caplog):
         assert ("MAIN.App1.App1_1", INFO, "End") in rec_tup
         assert ("MAIN.App1.App1_2", INFO, "End") in rec_tup
 
+        # Terminate (override method)
+        assert ("MAIN.App0", INFO, "Terminate.") in rec_tup
+        assert ("MAIN.App1", INFO, "Terminate.") in rec_tup
+        assert ("MAIN.App1.App1_1", INFO, "Terminate.") in rec_tup
+        assert ("MAIN.App1.App1_2", INFO, "Terminate.") in rec_tup
+
+        # terminate
+        assert("MAIN", DEBUG, "terminate") in rec_tup
+        assert("MAIN.App0", DEBUG, "terminate") in rec_tup
+        assert("MAIN.App1", DEBUG, "terminate") in rec_tup
+        assert("MAIN.App1.App1_1", DEBUG, "terminate") in rec_tup
+        assert("MAIN.App1.App1_2", DEBUG, "terminate") in rec_tup
+
     for record in caplog.records:
         assert record.levelno < WARNING, record.message


### PR DESCRIPTION
#16 #160 #89 
ADD override method `Terminate()` and default application log "terminate".
`Terminate()` is called before the app terminate. If child applications could not be terminated, this method is never called.