### PR TITLE
#168Rename launcher name

### DIFF
--- a/JarvisEngine/apps/launcher.py
+++ b/JarvisEngine/apps/launcher.py
@@ -1,19 +1,20 @@
 from .base_app import BaseApp, AttrDict
 from typing import *
 import os
-from ..core import logging_tool ,name as name_tools
+from ..core import name as name_tools
 from ..core.value_sharing import FolderDict_withLock
 import multiprocessing as mp
 from multiprocessing.managers import SyncManager
 import threading
 
+LAUNCHER_NAME = "Launcher"
 
 def to_project_config(config:AttrDict) -> AttrDict:
     """convert `config` to `project_config`
     `project_config` has the following structure.
     ```
     {
-        MAIN: {
+        Launcher: {
             path: "JarvisEngine.apps.Launcher",
             thread: true,
             apps: config
@@ -23,7 +24,7 @@ def to_project_config(config:AttrDict) -> AttrDict:
     ```
     """
     pconf_dict = {
-        logging_tool.MAIN_LOGGER_NAME:{
+        LAUNCHER_NAME:{
             "path": "JarvisEngine.apps.Launcher",
             "thread": False,
             "apps": config
@@ -41,7 +42,7 @@ class Launcher(BaseApp):
         """Initialize Launcher.
         converts `config` to `project_config`, and sets name.
         """
-        name = logging_tool.MAIN_LOGGER_NAME
+        name = LAUNCHER_NAME
         project_config = to_project_config(config)
         config = project_config[name]
         super().__init__(name, config, engine_config, project_config, project_dir)

--- a/TestEngineProject/App0/app.py
+++ b/TestEngineProject/App0/app.py
@@ -20,20 +20,20 @@ class App0(BaseApp):
 
     def Start(self) -> None:
         self.logger.info("Start")
-        assert self.getProcessSharedValue("MAIN.App0.bool_value") == True
-        assert self.getProcessSharedValue("MAIN.App1.int_value") == 100
-        assert self.getProcessSharedValue("MAIN.App1.App1_1.str_value") == "apple"
-        assert self.getProcessSharedValue("MAIN.App1.App1_2.float_value") == 0.0
+        assert self.getProcessSharedValue("Launcher.App0.bool_value") == True
+        assert self.getProcessSharedValue("Launcher.App1.int_value") == 100
+        assert self.getProcessSharedValue("Launcher.App1.App1_1.str_value") == "apple"
+        assert self.getProcessSharedValue("Launcher.App1.App1_2.float_value") == 0.0
 
-        assert self.getProcessSharedValue("MAIN.App0.shared_int").value == 0
-        assert self.getProcessSharedValue("MAIN.App1.shared_float").value == -10.0
-        assert self.getProcessSharedValue("MAIN.App1.App1_1.shared_bool").value == True
-        assert self.getProcessSharedValue("MAIN.App1.App1_2.shared_str").value == b"abc"
+        assert self.getProcessSharedValue("Launcher.App0.shared_int").value == 0
+        assert self.getProcessSharedValue("Launcher.App1.shared_float").value == -10.0
+        assert self.getProcessSharedValue("Launcher.App1.App1_1.shared_bool").value == True
+        assert self.getProcessSharedValue("Launcher.App1.App1_2.shared_str").value == b"abc"
 
-        assert self.getThreadSharedValue("MAIN.App0.set_obj") == {"number"}
-        assert self.getThreadSharedValue("MAIN.App1.range_obj") is None
-        assert self.getThreadSharedValue("MAIN.App1.App1_1.tuple_obj") is None
-        assert self.getThreadSharedValue("MAIN.App1.App1_2.list_obj") is None
+        assert self.getThreadSharedValue("Launcher.App0.set_obj") == {"number"}
+        assert self.getThreadSharedValue("Launcher.App1.range_obj") is None
+        assert self.getThreadSharedValue("Launcher.App1.App1_1.tuple_obj") is None
+        assert self.getThreadSharedValue("Launcher.App1.App1_2.list_obj") is None
 
     frame_rate = 0.0
     def Update(self, delta_time: float) -> None:

--- a/TestEngineProject/App1/App1_1/app.py
+++ b/TestEngineProject/App1/App1_1/app.py
@@ -22,20 +22,20 @@ class App1_1(BaseApp):
 
     def Start(self) -> None:
         self.logger.info("Start")
-        assert self.getProcessSharedValue("MAIN.App0.bool_value") == True
-        assert self.getProcessSharedValue("MAIN.App1.int_value") == 100
-        assert self.getProcessSharedValue("MAIN.App1.App1_1.str_value") == "apple"
-        assert self.getProcessSharedValue("MAIN.App1.App1_2.float_value") == 0.0
+        assert self.getProcessSharedValue("Launcher.App0.bool_value") == True
+        assert self.getProcessSharedValue("Launcher.App1.int_value") == 100
+        assert self.getProcessSharedValue("Launcher.App1.App1_1.str_value") == "apple"
+        assert self.getProcessSharedValue("Launcher.App1.App1_2.float_value") == 0.0
 
-        assert self.getProcessSharedValue("MAIN.App0.shared_int").value == 0
-        assert self.getProcessSharedValue("MAIN.App1.shared_float").value == -10.0
-        assert self.getProcessSharedValue("MAIN.App1.App1_1.shared_bool").value == True
-        assert self.getProcessSharedValue("MAIN.App1.App1_2.shared_str").value == b"abc"
+        assert self.getProcessSharedValue("Launcher.App0.shared_int").value == 0
+        assert self.getProcessSharedValue("Launcher.App1.shared_float").value == -10.0
+        assert self.getProcessSharedValue("Launcher.App1.App1_1.shared_bool").value == True
+        assert self.getProcessSharedValue("Launcher.App1.App1_2.shared_str").value == b"abc"
 
-        assert self.getThreadSharedValue("MAIN.App0.set_obj") is None
-        assert self.getThreadSharedValue("MAIN.App1.range_obj") == range(10)
-        assert self.getThreadSharedValue("MAIN.App1.App1_1.tuple_obj") == (True, False)
-        assert self.getThreadSharedValue("MAIN.App1.App1_2.list_obj") is None
+        assert self.getThreadSharedValue("Launcher.App0.set_obj") is None
+        assert self.getThreadSharedValue("Launcher.App1.range_obj") == range(10)
+        assert self.getThreadSharedValue("Launcher.App1.App1_1.tuple_obj") == (True, False)
+        assert self.getThreadSharedValue("Launcher.App1.App1_2.list_obj") is None
 
     frame_rate = 10
     def Update(self, delta_time: float) -> None:

--- a/TestEngineProject/App1/App1_2/app.py
+++ b/TestEngineProject/App1/App1_2/app.py
@@ -22,20 +22,20 @@ class App1_2(BaseApp):
 
     def Start(self) -> None:
         self.logger.info("Start")
-        assert self.getProcessSharedValue("MAIN.App0.bool_value") == True
-        assert self.getProcessSharedValue("MAIN.App1.int_value") == 100
-        assert self.getProcessSharedValue("MAIN.App1.App1_1.str_value") == "apple"
-        assert self.getProcessSharedValue("MAIN.App1.App1_2.float_value") == 0.0
+        assert self.getProcessSharedValue("Launcher.App0.bool_value") == True
+        assert self.getProcessSharedValue("Launcher.App1.int_value") == 100
+        assert self.getProcessSharedValue("Launcher.App1.App1_1.str_value") == "apple"
+        assert self.getProcessSharedValue("Launcher.App1.App1_2.float_value") == 0.0
 
-        assert self.getProcessSharedValue("MAIN.App0.shared_int").value == 0
-        assert self.getProcessSharedValue("MAIN.App1.shared_float").value == -10.0
-        assert self.getProcessSharedValue("MAIN.App1.App1_1.shared_bool").value == True
-        assert self.getProcessSharedValue("MAIN.App1.App1_2.shared_str").value == b"abc"
+        assert self.getProcessSharedValue("Launcher.App0.shared_int").value == 0
+        assert self.getProcessSharedValue("Launcher.App1.shared_float").value == -10.0
+        assert self.getProcessSharedValue("Launcher.App1.App1_1.shared_bool").value == True
+        assert self.getProcessSharedValue("Launcher.App1.App1_2.shared_str").value == b"abc"
 
-        assert self.getThreadSharedValue("MAIN.App0.set_obj") is None
-        assert self.getThreadSharedValue("MAIN.App1.range_obj") is None
-        assert self.getThreadSharedValue("MAIN.App1.App1_1.tuple_obj") is None
-        assert self.getThreadSharedValue("MAIN.App1.App1_2.list_obj") == [1,2,3]
+        assert self.getThreadSharedValue("Launcher.App0.set_obj") is None
+        assert self.getThreadSharedValue("Launcher.App1.range_obj") is None
+        assert self.getThreadSharedValue("Launcher.App1.App1_1.tuple_obj") is None
+        assert self.getThreadSharedValue("Launcher.App1.App1_2.list_obj") == [1,2,3]
 
     frame_rate = -1.0
     log_num = 5

--- a/TestEngineProject/App1/app.py
+++ b/TestEngineProject/App1/app.py
@@ -23,20 +23,20 @@ class App1(BaseApp):
 
     def Start(self) -> None:
         self.logger.info("Start")
-        assert self.getProcessSharedValue("MAIN.App0.bool_value") == True
-        assert self.getProcessSharedValue("MAIN.App1.int_value") == 100
-        assert self.getProcessSharedValue("MAIN.App1.App1_1.str_value") == "apple"
-        assert self.getProcessSharedValue("MAIN.App1.App1_2.float_value") == 0.0
+        assert self.getProcessSharedValue("Launcher.App0.bool_value") == True
+        assert self.getProcessSharedValue("Launcher.App1.int_value") == 100
+        assert self.getProcessSharedValue("Launcher.App1.App1_1.str_value") == "apple"
+        assert self.getProcessSharedValue("Launcher.App1.App1_2.float_value") == 0.0
         
-        assert self.getProcessSharedValue("MAIN.App0.shared_int").value == 0
-        assert self.getProcessSharedValue("MAIN.App1.shared_float").value == -10.0
-        assert self.getProcessSharedValue("MAIN.App1.App1_1.shared_bool").value == True
-        assert self.getProcessSharedValue("MAIN.App1.App1_2.shared_str").value == b"abc"
+        assert self.getProcessSharedValue("Launcher.App0.shared_int").value == 0
+        assert self.getProcessSharedValue("Launcher.App1.shared_float").value == -10.0
+        assert self.getProcessSharedValue("Launcher.App1.App1_1.shared_bool").value == True
+        assert self.getProcessSharedValue("Launcher.App1.App1_2.shared_str").value == b"abc"
 
-        assert self.getThreadSharedValue("MAIN.App0.set_obj") is None
-        assert self.getThreadSharedValue("MAIN.App1.range_obj") == range(10)
-        assert self.getThreadSharedValue("MAIN.App1.App1_1.tuple_obj") == (True, False)
-        assert self.getThreadSharedValue("MAIN.App1.App1_2.list_obj") is None
+        assert self.getThreadSharedValue("Launcher.App0.set_obj") is None
+        assert self.getThreadSharedValue("Launcher.App1.range_obj") == range(10)
+        assert self.getThreadSharedValue("Launcher.App1.App1_1.tuple_obj") == (True, False)
+        assert self.getThreadSharedValue("Launcher.App1.App1_2.list_obj") is None
 
     frame_rate = 5
     def Update(self, delta_time: float) -> None:

--- a/tests/apps/test_base_app.py
+++ b/tests/apps/test_base_app.py
@@ -52,8 +52,8 @@ def test_import_app():
 def test__init__():
     
     # test_properties():
-    name = "MAIN.App1.App1_1"
-    config = project_config.MAIN.apps.App1
+    name = "Launcher.App1.App1_1"
+    config = project_config.Launcher.apps.App1
     app_dir = "TestEngineProject/App1/App1_1"
     app = base_app.BaseApp(name, config, engine_config, project_config, app_dir)
     assert app.name == name
@@ -71,8 +71,8 @@ def test__init__():
     _check_property_override(app, "logger")
 
     # test_set_config_attrs():
-    name = "MAIN.App1"
-    config = project_config.MAIN.apps.App1
+    name = "Launcher.App1"
+    config = project_config.Launcher.apps.App1
     app_dir = "TestEngineProject/App1"
     app = base_app.BaseApp(name, config, engine_config, project_config, app_dir)
 
@@ -80,8 +80,8 @@ def test__init__():
     assert app.is_thread == config.thread
     assert app.child_app_configs == config.apps
 
-    name = "MAIN.App0"
-    config = project_config.MAIN.apps.App0
+    name = "Launcher.App0"
+    config = project_config.Launcher.apps.App0
     app_dir = "TestEngineProject/App0"
     app = base_app.BaseApp(name, config, engine_config, project_config, app_dir)
 
@@ -90,16 +90,16 @@ def test__init__():
     assert app.child_app_configs == base_app.AttrDict()
 
     # test construct_child_apps()
-    name = "MAIN.App1"
-    config = project_config.MAIN.apps.App1
+    name = "Launcher.App1"
+    config = project_config.Launcher.apps.App1
     app_dir = os.path.join(os.getcwd(), "App1")
     app = base_app.BaseApp(name, config, engine_config, project_config, app_dir)
 
     assert "App1_1" in app.child_apps
     assert "App1_2" in app.child_apps
     App1_1, App1_2 = app.child_apps["App1_1"], app.child_apps["App1_2"]
-    assert App1_1.name == "MAIN.App1.App1_1"
-    assert App1_2.name == "MAIN.App1.App1_2"
+    assert App1_1.name == "Launcher.App1.App1_1"
+    assert App1_2.name == "Launcher.App1.App1_2"
     assert App1_1.module_name == "App1.App1_1.app.App1_1"
     assert App1_2.module_name == "App1.App1_2.app.App1_2"
     assert App1_1.is_thread == True
@@ -124,8 +124,8 @@ def test__init__():
 
 @_cd_project_dir
 def test_process_shared_values():
-    name = "MAIN"
-    config = project_config.MAIN
+    name = "Launcher"
+    config = project_config.Launcher
     app_dir = PROJECT_DIR
     MainApp = base_app.BaseApp(name, config, engine_config,project_config,app_dir)
     
@@ -151,8 +151,8 @@ def test_process_shared_values():
 
 @_cd_project_dir
 def test_set_process_shared_values_to_all_apps():
-    name = "MAIN"
-    config = project_config.MAIN
+    name = "Launcher"
+    config = project_config.Launcher
     app_dir = PROJECT_DIR
     MainApp = base_app.BaseApp(name, config, engine_config,project_config,app_dir)
     
@@ -171,8 +171,8 @@ def test_set_process_shared_values_to_all_apps():
 
 @_cd_project_dir
 def test_thread_shared_values():
-    name = "MAIN"
-    config = project_config.MAIN
+    name = "Launcher"
+    config = project_config.Launcher
     app_dir = PROJECT_DIR
     MainApp = base_app.BaseApp(name, config, engine_config,project_config,app_dir)
     
@@ -185,8 +185,8 @@ def test_thread_shared_values():
 
 @_cd_project_dir
 def test_thread_shared_values():
-    name = "MAIN"
-    config = project_config.MAIN
+    name = "Launcher"
+    config = project_config.Launcher
     app_dir = PROJECT_DIR
     MainApp = base_app.BaseApp(name, config, engine_config,project_config,app_dir)
     
@@ -209,8 +209,8 @@ def test_thread_shared_values():
 
 @_cd_project_dir
 def test__add_shared_value():
-    name = "MAIN"
-    config = project_config.MAIN
+    name = "Launcher"
+    config = project_config.Launcher
     app_dir = PROJECT_DIR
     MainApp = base_app.BaseApp(name, config, engine_config,project_config,app_dir)
     
@@ -220,19 +220,19 @@ def test__add_shared_value():
     MainApp.set_thread_shared_values_to_all_apps(fdwl_thread)
 
     MainApp._add_shared_value("aaa", 10, for_thread=True)
-    assert MainApp.thread_shared_values["MAIN.aaa"] == 10
-    assert MainApp.process_shared_values["MAIN.aaa"] is None
-    assert fdwl_thread["MAIN.aaa"] == 10
+    assert MainApp.thread_shared_values["Launcher.aaa"] == 10
+    assert MainApp.process_shared_values["Launcher.aaa"] is None
+    assert fdwl_thread["Launcher.aaa"] == 10
 
     MainApp._add_shared_value("bbb",20,for_thread=False)
-    assert MainApp.thread_shared_values["MAIN.bbb"] is None
-    assert MainApp.process_shared_values["MAIN.bbb"] == 20
-    assert fdwl_process["MAIN.bbb"] == 20
+    assert MainApp.thread_shared_values["Launcher.bbb"] is None
+    assert MainApp.process_shared_values["Launcher.bbb"] == 20
+    assert fdwl_process["Launcher.bbb"] == 20
     
 @_cd_project_dir
 def test_addProcessSharedValue():
-    name = "MAIN"
-    config = project_config.MAIN
+    name = "Launcher"
+    config = project_config.Launcher
     app_dir = PROJECT_DIR
     MainApp = base_app.BaseApp(name, config, engine_config,project_config,app_dir)
     fdwl= FolderDict_withLock(sep=".")
@@ -241,14 +241,14 @@ def test_addProcessSharedValue():
     MainApp.addProcessSharedValue("ccc",30)
     MainApp.addProcessSharedValue("ddd",40)
     MainApp.addProcessSharedValue("eee",50)
-    assert MainApp.process_shared_values["MAIN.ccc"] == 30
-    assert MainApp.process_shared_values["MAIN.ddd"] == 40
-    assert MainApp.process_shared_values["MAIN.eee"] == 50
+    assert MainApp.process_shared_values["Launcher.ccc"] == 30
+    assert MainApp.process_shared_values["Launcher.ddd"] == 40
+    assert MainApp.process_shared_values["Launcher.eee"] == 50
 
 @_cd_project_dir
 def test_addThreadSharedValue():
-    name = "MAIN"
-    config = project_config.MAIN
+    name = "Launcher"
+    config = project_config.Launcher
     app_dir = PROJECT_DIR
     MainApp = base_app.BaseApp(name, config, engine_config,project_config,app_dir)
     fdwl= FolderDict_withLock(sep=".")
@@ -258,14 +258,14 @@ def test_addThreadSharedValue():
     MainApp.addThreadSharedValue("fff",60)
     MainApp.addThreadSharedValue("ggg",70)
     MainApp.addThreadSharedValue("hhh",80)
-    assert MainApp.thread_shared_values["MAIN.fff"] == 60
-    assert MainApp.thread_shared_values["MAIN.ggg"] == 70
-    assert MainApp.thread_shared_values["MAIN.hhh"] == 80
+    assert MainApp.thread_shared_values["Launcher.fff"] == 60
+    assert MainApp.thread_shared_values["Launcher.ggg"] == 70
+    assert MainApp.thread_shared_values["Launcher.hhh"] == 80
 
 @_cd_project_dir
 def test__get_shared_value():
-    name = "MAIN"
-    config = project_config.MAIN
+    name = "Launcher"
+    config = project_config.Launcher
     app_dir = PROJECT_DIR
     MainApp = base_app.BaseApp(name, config, engine_config,project_config,app_dir)
     
@@ -287,19 +287,19 @@ def test__get_shared_value():
     MainApp.addThreadSharedValue("eee",False)
     App0.addThreadSharedValue("fff",20)
 
-    assert MainApp._get_shared_value("MAIN.aaa",False) == 10
+    assert MainApp._get_shared_value("Launcher.aaa",False) == 10
     assert MainApp._get_shared_value(".aaa",False) == 10
-    assert MainApp._get_shared_value("MAIN.App0.bbb",False) == True
+    assert MainApp._get_shared_value("Launcher.App0.bbb",False) == True
     assert App0._get_shared_value("..App1.ccc", False) == "apple"
     assert App1._get_shared_value(".App1_1.ddd",False) == 1.0
     
-    assert MainApp._get_shared_value("..MAIN.eee",True) == False
-    assert App0._get_shared_value("MAIN.App0.fff" ,True) == 20
+    assert MainApp._get_shared_value("..Launcher.eee",True) == False
+    assert App0._get_shared_value("Launcher.App0.fff" ,True) == 20
 
 @_cd_project_dir
 def test_getProcessSharedValue():
-    name = "MAIN"
-    config = project_config.MAIN
+    name = "Launcher"
+    config = project_config.Launcher
     app_dir = PROJECT_DIR
     MainApp = base_app.BaseApp(name, config, engine_config,project_config,app_dir)
     fdwl_process= FolderDict_withLock(sep=".")
@@ -315,16 +315,16 @@ def test_getProcessSharedValue():
     App1_1.addProcessSharedValue("ddd",1.0) 
 
 
-    assert MainApp.getProcessSharedValue("MAIN.aaa") == 10
+    assert MainApp.getProcessSharedValue("Launcher.aaa") == 10
     assert MainApp.getProcessSharedValue(".aaa") == 10
-    assert MainApp.getProcessSharedValue("MAIN.App0.bbb") == True
+    assert MainApp.getProcessSharedValue("Launcher.App0.bbb") == True
     assert App0.getProcessSharedValue("..App1.ccc") == "apple"
     assert App1.getProcessSharedValue(".App1_1.ddd") == 1.0
 
 @_cd_project_dir
 def test_getThreadSharedValue():
-    name = "MAIN"
-    config = project_config.MAIN
+    name = "Launcher"
+    config = project_config.Launcher
     app_dir = PROJECT_DIR
     MainApp = base_app.BaseApp(name, config, engine_config,project_config,app_dir)
     fdwl_thread= FolderDict_withLock(sep=".")
@@ -336,33 +336,33 @@ def test_getThreadSharedValue():
     MainApp.addThreadSharedValue("eee",False)
     App0.addThreadSharedValue("fff",20)
 
-    assert MainApp.getThreadSharedValue("..MAIN.eee") == False
-    assert App0.getThreadSharedValue("MAIN.App0.fff") == 20
+    assert MainApp.getThreadSharedValue("..Launcher.eee") == False
+    assert App0.getThreadSharedValue("Launcher.App0.fff") == 20
 
 @_cd_project_dir
 def test_prepare_for_launching_thread_apps():
-    name = "MAIN"
-    config = project_config.MAIN
+    name = "Launcher"
+    config = project_config.Launcher
     app_dir = PROJECT_DIR
     MainApp = base_app.BaseApp(name, config, engine_config,project_config,app_dir)
     MainApp.prepare_for_launching_thread_apps()
 
     t_sv = MainApp.thread_shared_values
     assert isinstance(t_sv, FolderDict_withLock)
-    assert t_sv["MAIN.App0.set_obj"] == {"number"}
-    assert t_sv["MAIN.App1.range_obj"] is None
+    assert t_sv["Launcher.App0.set_obj"] == {"number"}
+    assert t_sv["Launcher.App1.range_obj"] is None
 
     App1 = MainApp.child_apps["App1"]
     App1.prepare_for_launching_thread_apps()
     t_sv = App1.thread_shared_values
-    assert t_sv["MAIN.App1.range_obj"] == range(10)
-    assert t_sv["MAIN.App1.App1_1.tuple_obj"] == (True, False)
-    assert t_sv["MAIN.App1.App1_2.list_obj"] is None
+    assert t_sv["Launcher.App1.range_obj"] == range(10)
+    assert t_sv["Launcher.App1.App1_1.tuple_obj"] == (True, False)
+    assert t_sv["Launcher.App1.App1_2.list_obj"] is None
 
 @_cd_project_dir
 def test_adjust_frame_rate():
-    name = "MAIN"
-    config = project_config.MAIN
+    name = "Launcher"
+    config = project_config.Launcher
     app_dir = PROJECT_DIR
     MainApp = base_app.BaseApp(name, config, engine_config,project_config,app_dir)
 

--- a/tests/apps/test_base_app_launch.py
+++ b/tests/apps/test_base_app_launch.py
@@ -27,8 +27,8 @@ class cd_project_dir:
         os.chdir("..")
 
 def test_launch(caplog):
-    name = "MAIN"
-    config = project_config.MAIN
+    name = "Launcher"
+    config = project_config.Launcher
     app_dir = PROJECT_DIR
     with cd_project_dir(), mp.Manager() as sync_manager:
         #MainApp = BaseApp(name, config, engine_config, project_config,app_dir)        
@@ -45,65 +45,65 @@ def test_launch(caplog):
         rec_tup = caplog.record_tuples
 
         # launch
-        assert ("MAIN", INFO, "launch") in rec_tup
-        assert ("MAIN.App0", INFO, "launch") in rec_tup
-        assert ("MAIN.App1", INFO, "launch") in rec_tup
-        assert ("MAIN.App1.App1_1", INFO, "launch") in rec_tup
-        assert ("MAIN.App1.App1_2", INFO, "launch") in rec_tup
+        assert ("Launcher", INFO, "launch") in rec_tup
+        assert ("Launcher.App0", INFO, "launch") in rec_tup
+        assert ("Launcher.App1", INFO, "launch") in rec_tup
+        assert ("Launcher.App1.App1_1", INFO, "launch") in rec_tup
+        assert ("Launcher.App1.App1_2", INFO, "launch") in rec_tup
         
         # Awake
-        assert ("MAIN.App0", INFO, "Awake") in rec_tup
-        assert ("MAIN.App1", INFO, "Awake") in rec_tup
-        assert ("MAIN.App1.App1_1", INFO, "Awake") in rec_tup
-        assert ("MAIN.App1.App1_2", INFO, "Awake") in rec_tup
+        assert ("Launcher.App0", INFO, "Awake") in rec_tup
+        assert ("Launcher.App1", INFO, "Awake") in rec_tup
+        assert ("Launcher.App1.App1_1", INFO, "Awake") in rec_tup
+        assert ("Launcher.App1.App1_2", INFO, "Awake") in rec_tup
 
         # Start
-        assert ("MAIN.App0", INFO, "Start") in rec_tup
-        assert ("MAIN.App1", INFO, "Start") in rec_tup
-        assert ("MAIN.App1.App1_1", INFO, "Start") in rec_tup
-        assert ("MAIN.App1.App1_2", INFO, "Start") in rec_tup
+        assert ("Launcher.App0", INFO, "Start") in rec_tup
+        assert ("Launcher.App1", INFO, "Start") in rec_tup
+        assert ("Launcher.App1.App1_1", INFO, "Start") in rec_tup
+        assert ("Launcher.App1.App1_2", INFO, "Start") in rec_tup
 
         # periodic_update
-        assert ("MAIN", DEBUG, "periodic update") in rec_tup
-        assert ("MAIN.App0", DEBUG, "periodic update") in rec_tup
-        assert ("MAIN.App1", DEBUG, "periodic update") in rec_tup
-        assert ("MAIN.App1.App1_1", DEBUG, "periodic update") in rec_tup
-        assert ("MAIN.App1.App1_2", DEBUG, "periodic update") in rec_tup
+        assert ("Launcher", DEBUG, "periodic update") in rec_tup
+        assert ("Launcher.App0", DEBUG, "periodic update") in rec_tup
+        assert ("Launcher.App1", DEBUG, "periodic update") in rec_tup
+        assert ("Launcher.App1.App1_1", DEBUG, "periodic update") in rec_tup
+        assert ("Launcher.App1.App1_2", DEBUG, "periodic update") in rec_tup
 
         # Update
         ### called only once.
-        assert ("MAIN.App0", INFO, "Update") in rec_tup
-        assert rec_tup.count(("MAIN.App0", INFO, "Update")) == 1
+        assert ("Launcher.App0", INFO, "Update") in rec_tup
+        assert rec_tup.count(("Launcher.App0", INFO, "Update")) == 1
 
         ### updating in 5 fps.
-        assert ("MAIN.App1", INFO, "Update") in rec_tup
-        assert 6 >= rec_tup.count(("MAIN.App1", INFO, "Update")) >= 4 
+        assert ("Launcher.App1", INFO, "Update") in rec_tup
+        assert 6 >= rec_tup.count(("Launcher.App1", INFO, "Update")) >= 4 
 
         ### updating in 10 fps.
-        assert ("MAIN.App1.App1_1", INFO, "Update") in rec_tup
-        assert 11 >= rec_tup.count(("MAIN.App1.App1_1", INFO, "Update")) >= 9
+        assert ("Launcher.App1.App1_1", INFO, "Update") in rec_tup
+        assert 11 >= rec_tup.count(("Launcher.App1.App1_1", INFO, "Update")) >= 9
 
         ### updating in infinity fps. logged only 5 times
-        assert rec_tup.count(("MAIN.App1.App1_2", INFO, "Update")) == 5
+        assert rec_tup.count(("Launcher.App1.App1_2", INFO, "Update")) == 5
 
         # End
-        assert ("MAIN.App0", INFO, "End") in rec_tup
-        assert ("MAIN.App1", INFO, "End") in rec_tup
-        assert ("MAIN.App1.App1_1", INFO, "End") in rec_tup
-        assert ("MAIN.App1.App1_2", INFO, "End") in rec_tup
+        assert ("Launcher.App0", INFO, "End") in rec_tup
+        assert ("Launcher.App1", INFO, "End") in rec_tup
+        assert ("Launcher.App1.App1_1", INFO, "End") in rec_tup
+        assert ("Launcher.App1.App1_2", INFO, "End") in rec_tup
 
         # Terminate (override method)
-        assert ("MAIN.App0", INFO, "Terminate.") in rec_tup
-        assert ("MAIN.App1", INFO, "Terminate.") in rec_tup
-        assert ("MAIN.App1.App1_1", INFO, "Terminate.") in rec_tup
-        assert ("MAIN.App1.App1_2", INFO, "Terminate.") in rec_tup
+        assert ("Launcher.App0", INFO, "Terminate.") in rec_tup
+        assert ("Launcher.App1", INFO, "Terminate.") in rec_tup
+        assert ("Launcher.App1.App1_1", INFO, "Terminate.") in rec_tup
+        assert ("Launcher.App1.App1_2", INFO, "Terminate.") in rec_tup
 
         # terminate
-        assert("MAIN", DEBUG, "terminate") in rec_tup
-        assert("MAIN.App0", DEBUG, "terminate") in rec_tup
-        assert("MAIN.App1", DEBUG, "terminate") in rec_tup
-        assert("MAIN.App1.App1_1", DEBUG, "terminate") in rec_tup
-        assert("MAIN.App1.App1_2", DEBUG, "terminate") in rec_tup
+        assert("Launcher", DEBUG, "terminate") in rec_tup
+        assert("Launcher.App0", DEBUG, "terminate") in rec_tup
+        assert("Launcher.App1", DEBUG, "terminate") in rec_tup
+        assert("Launcher.App1.App1_1", DEBUG, "terminate") in rec_tup
+        assert("Launcher.App1.App1_2", DEBUG, "terminate") in rec_tup
 
     for record in caplog.records:
         assert record.levelno < WARNING, record.message

--- a/tests/apps/test_base_app_override_methods.py
+++ b/tests/apps/test_base_app_override_methods.py
@@ -25,21 +25,21 @@ class cd_project_dir:
 
         
 def test_Init(caplog):
-    name = "MAIN"
-    config = project_config.MAIN
+    name = "Launcher"
+    config = project_config.Launcher
     app_dir = PROJECT_DIR
     with cd_project_dir():
         MainApp = base_app.BaseApp(name, config, engine_config,project_config,app_dir)
         time.sleep(0.1)
         rec_tup = caplog.record_tuples
-        assert ("MAIN.App0",INFO, "Init0") in rec_tup
-        assert ("MAIN.App1",INFO, "Init1") in rec_tup
-        assert ("MAIN.App1.App1_1",INFO, "Init1_1") in rec_tup
-        assert ("MAIN.App1.App1_2",INFO, "Init1_2") in rec_tup
+        assert ("Launcher.App0",INFO, "Init0") in rec_tup
+        assert ("Launcher.App1",INFO, "Init1") in rec_tup
+        assert ("Launcher.App1.App1_1",INFO, "Init1_1") in rec_tup
+        assert ("Launcher.App1.App1_2",INFO, "Init1_2") in rec_tup
 
 def test_RegisterProcessSharedValues():
-    name = "MAIN"
-    config = project_config.MAIN
+    name = "Launcher"
+    config = project_config.Launcher
     app_dir = PROJECT_DIR
     with mp.Manager() as shmm, cd_project_dir():
         MainApp = base_app.BaseApp(name, config, engine_config,project_config,app_dir)
@@ -47,14 +47,14 @@ def test_RegisterProcessSharedValues():
         MainApp.set_process_shared_values_to_all_apps(fdwl)
         MainApp.RegisterProcessSharedValues(shmm)
 
-        assert fdwl["MAIN.App1.int_value"] == 100
-        assert fdwl["MAIN.App1.App1_2.float_value"] == 0.0
-        assert fdwl["MAIN.App1.App1_1.str_value"] == "apple"
-        assert fdwl["MAIN.App0.bool_value"] == True
+        assert fdwl["Launcher.App1.int_value"] == 100
+        assert fdwl["Launcher.App1.App1_2.float_value"] == 0.0
+        assert fdwl["Launcher.App1.App1_1.str_value"] == "apple"
+        assert fdwl["Launcher.App0.bool_value"] == True
 
 def test_RegisterThreadSharedValues():
-    name = "MAIN"
-    config = project_config.MAIN
+    name = "Launcher"
+    config = project_config.Launcher
     app_dir = PROJECT_DIR
     with cd_project_dir():
         MainApp = base_app.BaseApp(name, config, engine_config,project_config,app_dir)
@@ -62,16 +62,16 @@ def test_RegisterThreadSharedValues():
         MainApp.set_thread_shared_values_to_all_apps(fdwl)
         MainApp.RegisterThreadSharedValues()
 
-        assert fdwl["MAIN.App0.set_obj"] == {"number"}
-        assert fdwl["MAIN.App1.range_obj"] is None
-        assert fdwl["MAIN.App1.App1_1.tuple_obj"] is None
-        assert fdwl["MAIN.App1.App1_2.list_obj"] is None
+        assert fdwl["Launcher.App0.set_obj"] == {"number"}
+        assert fdwl["Launcher.App1.range_obj"] is None
+        assert fdwl["Launcher.App1.App1_1.tuple_obj"] is None
+        assert fdwl["Launcher.App1.App1_2.list_obj"] is None
 
         fdwl = FolderDict_withLock(sep=".")
         App1 = MainApp.child_apps["App1"]
         App1.set_thread_shared_values_to_all_apps(fdwl)
         App1.RegisterThreadSharedValues()
-        assert fdwl["MAIN.App1.range_obj"] == range(10)
-        assert fdwl["MAIN.App1.App1_1.tuple_obj"] == (True, False)
-        assert fdwl["MAIN.App1.App1_2.list_obj"] is None
+        assert fdwl["Launcher.App1.range_obj"] == range(10)
+        assert fdwl["Launcher.App1.App1_1.tuple_obj"] == (True, False)
+        assert fdwl["Launcher.App1.App1_2.list_obj"] is None
         

--- a/tests/apps/test_launcher.py
+++ b/tests/apps/test_launcher.py
@@ -12,11 +12,14 @@ import multiprocessing as mp
 config = dict2attr(read_json(TEST_CONFIG_FILE_PATH))
 project_config = launcher.to_project_config(config)
 
+def test_LAUNCHER_NAME():
+    assert launcher.LAUNCHER_NAME == "Launcher"
+
 def test_to_project_config():
     config = AttrDict()
     proj_conf = launcher.to_project_config(config)
-    assert "MAIN" in proj_conf
-    launcher_conf = proj_conf.MAIN
+    assert "Launcher" in proj_conf
+    launcher_conf = proj_conf.Launcher
     assert launcher_conf.path == "JarvisEngine.apps.Launcher"
     mod, app = launcher_conf.path.rsplit(".",1)
     assert getattr(importlib.import_module(mod), app) == launcher.Launcher
@@ -27,8 +30,8 @@ def test_to_project_config():
 @_cd_project_dir
 def test__init__():
     lnchr = launcher.Launcher(config, engine_config,os.getcwd())
-    assert lnchr.name == logging_tool.MAIN_LOGGER_NAME
-    assert lnchr.config == project_config[logging_tool.MAIN_LOGGER_NAME]
+    assert lnchr.name == launcher.LAUNCHER_NAME
+    assert lnchr.config == project_config[launcher.LAUNCHER_NAME]
     assert lnchr.project_config == project_config
     assert lnchr.app_dir == os.getcwd()
 
@@ -44,7 +47,7 @@ def test_prepare_for_launching():
             for app2 in app.child_apps.values():
                 assert app2.process_shared_values is None
 
-        assert p_sv["MAIN.App1.int_value"] == 100
-        assert p_sv["MAIN.App1.App1_2.float_value"] == 0.0
-        assert p_sv["MAIN.App1.App1_1.str_value"] == "apple"
-        assert p_sv["MAIN.App0.bool_value"] == True
+        assert p_sv["Launcher.App1.int_value"] == 100
+        assert p_sv["Launcher.App1.App1_2.float_value"] == 0.0
+        assert p_sv["Launcher.App1.App1_1.str_value"] == "apple"
+        assert p_sv["Launcher.App0.bool_value"] == True


### PR DESCRIPTION
From #168 
全てのアプリケーションの起点であるLauncherの名前を`MAIN`から`Launcher`に変更しました。
それに伴って以下のファイルが更新されました。

Renamed Launcher Application `MAIN` to `Launcher`.
Accordingly, the following files were changed.

- JarvisEngine/apps/launcher.py
- tests/apps/test_launcher.py
- tests/apps/test_base_app.py
- tests/apps/test_base_app_override_methods.py
- tests/apps/test_base_app_launch.py
- all app.py in TestEngineProject dir.