### PR TITLE
Config tools/add test of reading json and json5

### DIFF
--- a/tests/core/test_config.json
+++ b/tests/core/test_config.json
@@ -1,0 +1,9 @@
+{
+    "name": "kazuya",
+    "age": 17,
+    "sex": {
+        "real": "male",
+        "virtual": null
+    },
+    "student": false
+}

--- a/tests/core/test_config_tools.py
+++ b/tests/core/test_config_tools.py
@@ -15,6 +15,15 @@ def test_read_toml():
 
 
 def test_read_json():
+    conf = config_tools.read_json("tests/core/test_config.json")
+    assert conf["name"] == "kazuya"
+    assert conf["age"] == 17
+    assert conf["sex"]["real"] == "male"
+    assert conf["sex"]["virtual"] is None
+    assert conf["student"] is False
+
+
+def test_read_json5():
     conf = config_tools.read_json("tests/core/test_config.json5")
     assert conf["name"] == "geson"
     assert conf["age"] == 18


### PR DESCRIPTION
#57 ADD test to read `json` and `json5` since `read_json` can read both file formats.